### PR TITLE
force the R environment to use cairo for PNGs instead of trying Xlib

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,9 @@ RUN Rscript --no-save /install_packages_or_die.R spdep
 COPY start_shiny_app.R /opt/covid/start_shiny_app.R
 COPY start_shiny_app /opt/covid/start_shiny_app
 
+# cairo is available, but sadly not found first, so force to find it.
+RUN echo "options(bitmapType='cairo')" > /usr/local/lib64/R/etc/Rprofile.site
+
 COPY user-setup.sh /opt/covid/user-setup.sh
 RUN /opt/covid/user-setup.sh
 


### PR DESCRIPTION
PNGs are currently failing for some reason that's not entirely clear.  We have the right libraries, but somehow 

For some reason, this defaults to Xlib which is problematic.
```text
> getOption('bitmapType')
[1] "Xlib"
```

```text
> png('foo')
Error in .External2(C_X11, paste0("png::", filename), g$width, g$height,  : 
  unable to start device PNG
In addition: Warning message:
In png("foo") : unable to open connection to X11 display ''
> options(bitmapType='cairo')
> png('foo')
> 
```

So the simplest fix is to create a site file that forces the option.